### PR TITLE
[Solo] Add anchor link to content headings

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -767,6 +767,22 @@ hr {
     }
 }
 
+.anchor-link {
+    opacity: 0;
+    text-decoration: none;
+    margin-left: 0em;
+}
+
+h1:hover .anchor-link,
+h2:hover .anchor-link,
+h3:hover .anchor-link,
+h4:hover .anchor-link,
+h5:hover .anchor-link,
+h6:hover .anchor-link {
+    opacity: 1;
+    text-decoration: none;
+}
+
 /* Custom CTA
 /* ---------------------------------------------------------- */
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -52,3 +52,18 @@ function initParallax() {
 (function () {
     pagination(true, initParallax);
 })();
+
+(function (window, document) {
+    var addAnchors = () => {
+        var headings = document.querySelectorAll('.gh-content h1, .gh-content h2, .gh-content h3, gh-.content h4, .gh-content h5, .gh-content h6')
+        headings.forEach((heading) => {
+            heading.insertAdjacentHTML('beforeend', `
+                <a href="#${heading.id}" class="anchor-link">
+                    <svg width="1em" height="0.85em" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path></svg>
+                </a>
+            `)
+        })
+    }
+
+    document.addEventListener('DOMContentLoaded', addAnchors)
+})(window, document);


### PR DESCRIPTION
This change adds anchor links to post headings, enabling you to share deep links to your articles so that people can navigate directly to the relevant content you're trying to share. The anchor link is hidden until you hover over (or touch) the heading, and once it's displayed you can copy the link to share it with someone else.

Here's a demo of what it looks like:

https://user-images.githubusercontent.com/972799/204453424-168da99a-b1d7-48fc-825a-583b895d6a70.mp4

This feature is really useful when you write longer-form content and want to share a specific section with someone, or if you're trying to link to specific sections within your own content.

If there are any questions or concerns about this change, please let me know. Thanks for the consideration!