### PR TITLE
Show all tags for a post rather than the "primary" tag only

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -595,12 +595,15 @@ hr {
     top: 48px;
     display: flex;
     flex-direction: column;
+    flex-wrap: wrap;
+    gap: 16px;
+    padding-right: 16px;
 }
 
 .gh-article-meta .gh-author-image {
     width: 72px;
     height: 72px;
-    margin-bottom: 16px;
+    margin-bottom: 0;
 }
 
 .gh-article-meta .gh-author-name {
@@ -620,10 +623,15 @@ hr {
     color: var(--color-secondary-text);
 }
 
+.gh-article-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
 .gh-article-tag {
     width: fit-content;
     padding: 2px 12px;
-    margin-top: 20px;
     font-size: 1.5rem;
     font-weight: 700;
     color: var(--tag-color, var(--color-darker-gray)) !important;
@@ -745,21 +753,21 @@ hr {
     .gh-article-meta-inner {
         flex-direction: row;
         align-items: center;
+        gap: 12px;
+        padding-right: 0;
     }
 
     .gh-article-meta .gh-author-image {
         width: 64px;
         height: 64px;
-        margin-right: 12px;
-        margin-bottom: 0;
     }
 
     .gh-article-meta-wrapper {
         flex-grow: 1;
     }
 
-    .gh-article-tag {
-        margin-top: 0;
+    .gh-article-tags {
+        gap: 6px;
     }
 }
 

--- a/post.hbs
+++ b/post.hbs
@@ -38,8 +38,12 @@
                                 </h4>
                             {{/primary_author}}
                             <time class="gh-article-date" datetime="{{date format="YYYY-MM-DD"}}">{{date}}</time></div>
-                            {{#if primary_tag}}
-                                <a class="gh-article-tag" href="{{primary_tag.url}}" style="--tag-color: {{primary_tag.accent_color}}">{{primary_tag.name}}</a>
+                            {{#if tags}}
+                                <div class="gh-article-tags">
+                                    {{#foreach}}
+                                        <a class="gh-article-tag tag--{{slug}}" href="{{url}}" style="--tag-color: {{accent_color}}">{{name}}</a>
+                                    {{/foreach}}
+                                </div>
                             {{/if}}
                         </div>
                     </aside>

--- a/post.hbs
+++ b/post.hbs
@@ -40,7 +40,7 @@
                             <time class="gh-article-date" datetime="{{date format="YYYY-MM-DD"}}">{{date}}</time></div>
                             {{#if tags}}
                                 <div class="gh-article-tags">
-                                    {{#foreach}}
+                                    {{#foreach tags}}
                                         <a class="gh-article-tag tag--{{slug}}" href="{{url}}" style="--tag-color: {{accent_color}}">{{name}}</a>
                                     {{/foreach}}
                                 </div>


### PR DESCRIPTION
Currently, a post with multiple tags only shows the first tag, called the "primary" tag. I don't think there's a compelling reason we wouldn't want to show all tags attached to the post, especially on the post page itself.

These changes slightly restyle the post metadata to make better use of Flexbox's gap feature, simplifying metadata spacing at different viewport widths.

There's currently one breakpoint on the post page at 991/992px that affects the metadata layout. I'm including screenshots at 991px and 992px viewport widths as well as how Safari's inspector sees the layout for the new `.gh-article-meta-inner` and `.gh-article-tags` styling.


### Wide viewport, many tags

| Page view | Metadata layout | Tag layout |
|:---:|:---:|:---:|
| <img width="1280" alt="Screenshot 2023-12-12 at 2 31 12 PM" src="https://github.com/TryGhost/Solo/assets/34264/bfc3669c-c1ae-4973-9535-d870821ae691"> | <img width="1280" alt="Screenshot 2023-12-12 at 2 31 17 PM" src="https://github.com/TryGhost/Solo/assets/34264/073f0548-9dcd-4092-9fba-121030618be0"> | <img width="1280" alt="Screenshot 2023-12-12 at 2 31 34 PM" src="https://github.com/TryGhost/Solo/assets/34264/c4e15da1-705c-4227-9afc-f262cc2d556c"> |

### Narrow viewport, many tags

| Page view | Metadata layout | Tag layout |
|:---:|:---:|:---:|
| <img width="1280" alt="Screenshot 2023-12-12 at 2 35 02 PM" src="https://github.com/TryGhost/Solo/assets/34264/b2846cdf-6dfc-4fc7-9383-fa5e076b319e"> | <img width="1280" alt="Screenshot 2023-12-12 at 2 35 10 PM" src="https://github.com/TryGhost/Solo/assets/34264/8a33e109-cdc5-49c7-a311-b120e96c4535"> | <img width="1280" alt="Screenshot 2023-12-12 at 2 35 25 PM" src="https://github.com/TryGhost/Solo/assets/34264/49b7bd93-18e6-4990-a04a-531a3842e013"> |

### Narrow viewport, fewer tags

| Page view | Metadata layout | Tag layout |
|:---:|:---:|:---:|
| <img width="1280" alt="Screenshot 2023-12-12 at 2 35 56 PM" src="https://github.com/TryGhost/Solo/assets/34264/6336e7fe-1e10-4aa0-97f5-1cca1075cd9f"> | <img width="1280" alt="Screenshot 2023-12-12 at 2 36 06 PM" src="https://github.com/TryGhost/Solo/assets/34264/555f7eaa-236b-43ac-bbd0-5843702d73e1"> | <img width="1280" alt="Screenshot 2023-12-12 at 2 36 25 PM" src="https://github.com/TryGhost/Solo/assets/34264/306f77ea-dea5-4986-9d30-337fc13bd582"> |

⚠️ **I don't have a Ghost(Pro) plan that allows uploading a custom theme!** I made small reasonable changes to the `post.hbs` template but wasn't able to test them locally yet.