### PR TITLE
Improve srcsets and add where missing

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -9,7 +9,12 @@
 
     {{#is "home"}}
         {{#if @site.cover_image}}
+        {{#match @custom.header_section_layout "Large background"}}
             <link rel="preload" as="image" href="{{@site.cover_image}}">
+        {{else match @custom.header_section_layout "Side by side"}}
+            <link rel="preload" as="image" href="{{img_url @site.cover_image size="m"}}">
+        {{/match}}
+
         {{/if}}
     {{/is}}
 
@@ -46,8 +51,8 @@
                     <a class="gh-head-logo" href="{{@site.url}}">
                         {{#if @site.logo}}
                             <img srcset="{{img_url @site.logo size="s"}} 300w,
-                                {{img_url @site.logo size="m"}} 600w"
-                                sizes="(max-width: 600px) 50vw, 40vw"
+                                {{img_url @site.logo size="m"}} 720w"
+                                sizes="90vw"
                             src="{{img_url @site.logo size="s"}}" alt="{{@site.title}}"
                             >
                         {{else}}

--- a/default.hbs
+++ b/default.hbs
@@ -45,7 +45,11 @@
                 <div class="gh-head-brand-wrapper">
                     <a class="gh-head-logo" href="{{@site.url}}">
                         {{#if @site.logo}}
-                            <img src="{{@site.logo}}" alt="{{@site.title}}">
+                            <img srcset="{{img_url @site.logo size="s"}} 300w,
+                                {{img_url @site.logo size="m"}} 600w"
+                                sizes="(max-width: 600px) 50vw, 40vw"
+                            src="{{img_url @site.logo size="s"}}" alt="{{@site.title}}"
+                            >
                         {{else}}
                             {{@site.title}}
                         {{/if}}

--- a/index.hbs
+++ b/index.hbs
@@ -18,9 +18,8 @@
                 {{#if @site.cover_image}}
                     <img class="gh-about-image" 
                         srcset="{{img_url @site.cover_image size="s"}} 300w,
-                            {{img_url @site.cover_image size="m"}} 720w,
-                            {{img_url @site.cover_image size="l"}} 960w"
-                        sizes="(max-width: 840px) 100vw, 50vw"
+                            {{img_url @site.cover_image size="m"}} 720w"
+                        sizes="(max-width: 720px) 100vw, 50vw"
                         src="{{@site.cover_image}}" alt="{{@site.title}}">
                 {{/if}}                
             {{/match}}

--- a/index.hbs
+++ b/index.hbs
@@ -3,9 +3,27 @@
 <section class="gh-about gh-outer{{#match @custom.header_section_layout "!=" "Typographic profile"}}{{#unless @site.cover_image}} no-image{{/unless}}{{else}}{{#unless @site.icon}} no-image{{/unless}}{{/match}}">
     <div class="gh-about-inner gh-inner">
         {{#match @custom.header_section_layout "!=" "Typographic profile"}}
-            {{#if @site.cover_image}}
-                <img class="gh-about-image" src="{{@site.cover_image}}" alt="{{@site.title}}">
-            {{/if}}
+            {{#match @custom.header_section_layout "=" "Large background"}}
+                {{#if @site.cover_image}}
+                    <img class="gh-about-image" 
+                        srcset="{{img_url @site.cover_image size="s"}} 300w,
+                            {{img_url @site.cover_image size="m"}} 720w,
+                            {{img_url @site.cover_image size="l"}} 960w,
+                            {{img_url @site.cover_image size="xl"}} 1200w,
+                            {{img_url @site.cover_image size="xxl"}} 2000w"
+                        sizes="100vw"
+                        src="{{@site.cover_image}}" alt="{{@site.title}}">
+                {{/if}}
+            {{else}}
+                {{#if @site.cover_image}}
+                    <img class="gh-about-image" 
+                        srcset="{{img_url @site.cover_image size="s"}} 300w,
+                            {{img_url @site.cover_image size="m"}} 720w,
+                            {{img_url @site.cover_image size="l"}} 960w"
+                        sizes="(max-width: 840px) 100vw, 50vw"
+                        src="{{@site.cover_image}}" alt="{{@site.title}}">
+                {{/if}}                
+            {{/match}}
         {{else}}
             {{#if @site.icon}}
                 <img class="gh-about-image" src="{{@site.icon}}" alt="{{@site.title}}">

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -8,10 +8,14 @@
                         {{#match @custom.post_feed_layout "Parallax"}}class="jarallax-img"{{/match}}
                         srcset="{{img_url feature_image size="s"}} 300w,
                                 {{img_url feature_image size="m"}} 720w,
-                                {{img_url feature_image size="l"}} 960w,
+                                {{img_url feature_image size="l"}} 960w
+                        {{#match @custom.post_feed_layout "=" "Parallax"}},
                                 {{img_url feature_image size="xl"}} 1200w,
                                 {{img_url feature_image size="xxl"}} 2000w"
-                        sizes="(max-width: 1200px) 100vw, 1200px"
+                        sizes="(max-width: 1440px) 100vw, 1440px"
+                        {{else}}
+                        sizes="(max-width: 991px) 100vw, 50vw"
+                        {{/match}}
                         src="{{img_url feature_image size="m"}}"
                         alt="{{#if feature_image_alt}}{{feature_image_alt}}{{else}}{{title}}{{/if}}"
                     >


### PR DESCRIPTION
Hello!
Offering the following improvements to Solo image handling:
1) Logo:  Previously no srcset, loaded full size logo (which could be /very/ big.  The challenge is that we don't have the dimensions for the user's logo, and the height restriction (48px) is driving how big it can be.  It's mostly loading the 720w version, because I could imaging a case with a very wide and short logo where that'd be appropriate.  An improvement over loading a worst-case 2000px+ image, at least.
2) Hero image:  The code previously loaded a very large image, in case the "Large background" theme option was selected.  I split out the logic, so that a smaller image loads for the more commonly-used side by side layout.
3) Loop images:  Similar to the hero image, it was loading a very large image in case the Parallax view was used, but the classic layout needed a much smaller image.  I split the logic.
